### PR TITLE
Add Diffux-CI to list of command-line tools

### DIFF
--- a/source/contents/techniques/image-diff.md
+++ b/source/contents/techniques/image-diff.md
@@ -14,14 +14,15 @@ This is probably the most common technique employed for CSS testing as it direct
 
 ### Content Fragile
 
-It is *content-fragile*. Any copy changes will break tests. Even something as simple as a 'last updated on' date in the footer of a page will trigger a failure exactly the same as an actual error would. This can be worked around by testing entirely with mocked content or by only running image diff tests against a '[living styleguide](guides/living-styleguide.html)' if your project uses one. The project '[Wraith](/tools/wraith.html)' generates the comparison images at run-time against the current production server to minimise any time-dependant content differences.
+It is *content-fragile*. Any copy changes will break tests. Even something as simple as a 'last updated on' date in the footer of a page will trigger a failure exactly the same as an actual error would. This can be worked around by testing entirely with mocked content or by only running image diff tests against a '[living styleguide](guides/living-styleguide.html)' if your project uses one. The project '[Wraith](/tools/wraith.html)' generates the comparison images at run-time against the current production server to minimise any time-dependant content differences. With [Diffux-CI](/tools/diffux-ci.html), you are in control of the data used to snapshot and compare individual components.
 
 ### DOM-unaware
 
-Once the page or element has been flattened down to an image, it has no relation to the underlying DOM structure. This makes it harder to identify the root cause of the problem it has identified. You know that something has gone wrong but you'll still need to spend time figuring out exactly where.
+Once the page or element has been flattened down to an image, it has no relation to the underlying DOM structure. This makes it harder to identify the root cause of the problem it has identified. You know that something has gone wrong but you'll still need to spend time figuring out exactly where. Good image diffing tools will run diffs for every commit you make. This makes it easier to pin-point what change introduced the problem.
 
 ### Tools
 
   * [CSSCritic](/tools/csscritic.html)
+  * [Diffux-CI](/tools/diffux-ci.html)
   * [PhantomCSS](/tools/phantomcss.html)
   * [Wraith](/tools/wraith.html)

--- a/source/contents/tools/diffux-ci.md
+++ b/source/contents/tools/diffux-ci.md
@@ -1,0 +1,23 @@
+---
+template: layout.jade
+section: tools
+title: Diffux-CI
+---
+
+## Diffux-CI
+
+[Diffux-CI](https://github.com/diffux/diffux_ci) checks your JavaScript
+components for visual regressions. It is designed to integrate with any
+continuous integration environment (such as [Jenkins](https://jenkins-ci.org/),
+[Travis](https://travis-ci.org/), and others) and will help you catch bugs
+before they end up in production. With its clear focus on components,
+[React](https://facebook.github.io/react/) applications are perfectly suited
+for Diffux-CI.
+
+Make sure to check out [the blog post introducing
+Diffux-CI](https://medium.com/brigade-engineering/the-end-of-visual-regressions-b6b5c3d810f).
+
+### Links
+
+  * [Source code](https://github.com/diffux/diffux_ci)
+  * [Blog post](https://medium.com/brigade-engineering/the-end-of-visual-regressions-b6b5c3d810f)

--- a/source/contents/tools/index.md
+++ b/source/contents/tools/index.md
@@ -13,6 +13,7 @@ Here, we'll list all the known tools, browser extensions and services.
     * [CSSCritic](csscritic.html)
     * [cssert](cssert.html)
     * [CSSLint](csslint.html)
+    * [Diffux-CI](diffux-ci.html)
     * [Fighting Layout Bugs](fighting-layout-bugs.html)
     * [GhostStory](ghoststory.html)
     * [Hardy](hardy.html)


### PR DESCRIPTION
Diffux-CI is a project that @lencioni and I have developed with the goal
of eliminating visual regressions. A few years ago, we co-created
[Diffux](https://github.com/diffux/diffux), a tool to find visual bugs.
Whereas Diffux was all about diffing full pages, Diffux-CI is about
diffing individual components. It is designed to integrate with CI, and
it uses Firefox to take snapshots. Since we introduced Diffux-CI in the
brigade.com codebase six months ago, we've prevented countless visual
regressions and we feel more confident than ever making changes to our
CSS.
